### PR TITLE
fix: change sql time command to unix time

### DIFF
--- a/server/server/controllers/order_controller.js
+++ b/server/server/controllers/order_controller.js
@@ -43,7 +43,7 @@ const checkout = async (req, res) => {
 
     // for testing purpose, set delivery date to 2 minutes later
     const deliveryDate = new Date();
-    deliveryDate.setMinutes(deliveryDate.getMinutes() + 2);
+    deliveryDate.setMinutes(deliveryDate.getMinutes() + 1);
 
     console.log("timetime", deliveryDate.getTime());
     await Order.setDeliveryDate(orderId, deliveryDate.getTime());

--- a/server/server/models/order_model.js
+++ b/server/server/models/order_model.js
@@ -67,7 +67,7 @@ const getPendingOrders = async () => {
       SELECT o.*, u.line_notify_token 
       FROM order_table o
       JOIN user u ON o.user_id = u.id
-      WHERE o.delivery_date < NOW() AND o.is_notification_sent = false
+      WHERE o.delivery_date < UNIX_TIMESTAMP(NOW(3)) * 1000 AND o.is_notification_sent = false
     `;
     const [orders] = await pool.execute(query);
     return orders;


### PR DESCRIPTION
The original sql command is NOW(), but this return the datetime instead of the unix time (e.g. 17000000000). 

Current commit fix this problem by changing it to UNIX_TIMESTAMP(NOW(3)) * 1000 so that the time comparison in checking whether to send notification is working now.